### PR TITLE
Adds support for generic responses

### DIFF
--- a/sdk/schema.go
+++ b/sdk/schema.go
@@ -55,38 +55,7 @@ type DeploymentResource struct {
 	RequestID       string                 `json:"requestId,omitempty"`
 	ResourceID      string                 `json:"resourceId,omitempty"`
 	ResourceType    string                 `json:"resourceType,omitempty"`
-	ResourcesData   DeploymentResourceData `json:"data,omitempty"`
-}
-
-// DeploymentResourceData - view of the resources/machines in a deployment
-type DeploymentResourceData struct {
-	Memory                      int    `json:"MachineMemory,omitempty"`
-	CPU                         int    `json:"MachineCPU,omitempty"`
-	IPAddress                   string `json:"ip_address,omitempty"`
-	Storage                     int    `json:"MachineStorage,omitempty"`
-	MachineInterfaceType        string `json:"MachineInterfaceType,omitempty"`
-	MachineName                 string `json:"MachineName,omitempty"`
-	MachineGuestOperatingSystem string `json:"MachineGuestOperatingSystem,omitempty"`
-	MachineDestructionDate      string `json:"MachineDestructionDate,omitempty"`
-	MachineGroupName            string `json:"MachineGroupName,omitempty"`
-	MachineBlueprintName        string `json:"MachineBlueprintName,omitempty"`
-	MachineReservationName      string `json:"MachineReservationName,omitempty"`
-	MachineType                 string `json:"MachineType,omitempty"`
-	MachineID                   string `json:"machineId,omitempty"`
-	MachineExpirationDate       string `json:"MachineExpirationDate,omitempty"`
-	Component                   string `json:"Component,omitempty"`
-	Expire                      bool   `json:"Expire,omitempty"`
-	Reconfigure                 bool   `json:"Reconfigure,omitempty"`
-	Reset                       bool   `json:"Reset,omitempty"`
-	Reboot                      bool   `json:"Reboot,omitempty"`
-	PowerOff                    bool   `json:"PowerOff,omitempty"`
-	Destroy                     bool   `json:"Destroy,omitempty"`
-	Shutdown                    bool   `json:"Shutdown,omitempty"`
-	Suspend                     bool   `json:"Suspend,omitempty"`
-	Reprovision                 bool   `json:"Reprovision,omitempty"`
-	ChangeLease                 bool   `json:"ChangeLease,omitempty"`
-	ChangeOwner                 bool   `json:"ChangeOwner,omitempty"`
-	CreateSnapshot              bool   `json:"CreateSnapshot,omitempty"`
+	ResourcesData   map[string]interface{} `json:"data,omitempty"`
 }
 
 // ResourceActions - Retrieves the resources that were provisioned as a result of a given request.

--- a/utils/utilities_test.go
+++ b/utils/utilities_test.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestFlatten(t *testing.T) {
+	inside := make(map[string]interface{})
+	inside["outside"] = "valid"
+	outside := make(map[string]interface{})
+	outside["test"] = inside
+	actual := Flatten(outside)
+
+	expected := make(map[string]interface{})
+	expected["test.outside"] = "valid"
+
+	for k := range actual {
+		if actual[k] != expected[k] {
+			t.Fatalf("Expected %s, got %s at key %s", expected, actual, k)
+		}
+	}
+}
+
+func TestFlattenComplex(t *testing.T) {
+	deep := make(map[string]interface{})
+	deep["outside"] = "valid"
+
+	inside := make(map[string]interface{})
+	inside["outside"] = "valid"
+	inside["deep"] = deep
+
+	outside := make(map[string]interface{})
+	outside["test"] = inside
+	actual := Flatten(outside)
+
+	expected := make(map[string]interface{})
+	expected["test.outside"] = "valid"
+	expected["test.deep.outside"] = "valid"
+
+	for k := range actual {
+		if actual[k] != expected[k] {
+			t.Fatalf("Expected %s, got %s at key %s", expected, actual, k)
+		}
+	}
+}


### PR DESCRIPTION
Uses Go `map[string]string` instead of `DeploymentResourceData`
to abstract generic properties from the responses of vRA deployment
resources.

This solves issues where we might want to handle custom properties on
the blueprints, as well as XaaS blueprints that contain entirely custom
properties.

Signed-off-by: skylerto <skylerclayne@gmail.com>