### PR TITLE
Enable request/response logging

### DIFF
--- a/sdk/vra7_client.go
+++ b/sdk/vra7_client.go
@@ -6,15 +6,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/hashicorp/terraform/helper/logging"
 )
 
 // NewClient creates a new APIClient object
 func NewClient(user, password, tenant, baseURL string, insecure bool) APIClient {
 
-	transport := http.DefaultTransport.(*http.Transport)
-	transport.TLSClientConfig = &tls.Config{
+	t := http.DefaultTransport.(*http.Transport)
+	t.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: insecure,
 	}
+	transport := logging.NewTransport("VRA7", t)
 	httpClient := &http.Client{
 		// Timeout:   clientTimeout,
 		Transport: transport,


### PR DESCRIPTION
This makes debugging for developers & users of this provider easier by
exposing all requests & responses in the log (when >DEBUG severity is
set).

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>