### PR TITLE
Added support for deployment destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ resource "vra7_deployment" "example_machine2" {
 
 Save this configuration in `main.tf` in a path where the binary is placed.
 
+### Deployment Destroy
+In case you are encountering the following error in vRA7:
+```
+Insufficient entitlement to destroy VM
+```
+Please set `deployment_destroy = true` which will cause the provider to destroy the deployment resource instead.
+
 ### Nested structures
 
 At the moment Terraform SDK does not support nested dynamic types, which are used by vRA API.

--- a/sdk/vra7_sdk.go
+++ b/sdk/vra7_sdk.go
@@ -55,6 +55,7 @@ const (
 	Component              = "Component"
 	Reconfigure            = "Reconfigure"
 	Destroy                = "Destroy"
+	DeploymentDestroy      = "Deployment Destroy"
 )
 
 // GetCatalogItemRequestTemplate - Call to retrieve a request template for a catalog item.

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -40,6 +40,7 @@ type ProviderSchema struct {
 	FailedMessage           string
 	DeploymentConfiguration map[string]interface{}
 	ResourceConfiguration   map[string]interface{}
+	DeploymentDestroy       bool
 }
 
 func resourceVra7Deployment() *schema.Resource {
@@ -105,6 +106,10 @@ func resourceVra7Deployment() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				Elem:     schema.TypeString,
+			},
+			"deployment_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 		},
 	}
@@ -392,6 +397,8 @@ func resourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) error 
 //Terraform call - terraform destroy
 func resourceVra7DeploymentDelete(d *schema.ResourceData, meta interface{}) error {
 	vraClient = meta.(*sdk.APIClient)
+	// Get client handle
+	p := readProviderConfiguration(d)
 	//Get requester machine ID from schema.dataresource
 	catalogItemRequestID := d.Id()
 	// Throw an error if request ID has no value or empty value
@@ -421,7 +428,7 @@ func resourceVra7DeploymentDelete(d *schema.ResourceData, meta interface{}) erro
 			var destroyEnabled bool
 			var destroyActionID string
 			for _, op := range resources.Operations {
-				if op.Name == sdk.Destroy {
+				if (p.DeploymentDestroy && op.Name == sdk.DeploymentDestroy) || (!p.DeploymentDestroy && op.Name == sdk.Destroy) {
 					destroyEnabled = true
 					destroyActionID = op.OperationID
 					break
@@ -624,6 +631,7 @@ func readProviderConfiguration(d *schema.ResourceData) *ProviderSchema {
 		FailedMessage:           strings.TrimSpace(d.Get("failed_message").(string)),
 		ResourceConfiguration:   d.Get("resource_configuration").(map[string]interface{}),
 		DeploymentConfiguration: d.Get("deployment_configuration").(map[string]interface{}),
+		DeploymentDestroy:       d.Get("deployment_destroy").(bool),
 	}
 
 	log.Info("The values provided in the TF config file is: \n %v ", providerSchema)


### PR DESCRIPTION
The current provider fails on Swisscom Enterprise Service cloud due to: Insufficient entitlement to destroy VM in vRA7 otherwise

This patch addresses this issue.