### PR TITLE
set "cluster" value to 1 is scaling is not enabled in blueprint

### DIFF
--- a/vra7/data_source_vra7_deployment.go
+++ b/vra7/data_source_vra7_deployment.go
@@ -161,8 +161,16 @@ func dataSourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) erro
 			scaleOutActionID := deploymentActionsMap["Scale Out"]
 			resourceActionTemplate, _ := vraClient.GetResourceActionTemplate(parentResourceID, scaleOutActionID)
 			actionTemplateResourceDataMap := GetActionTemplateDataByComponent(resourceActionTemplate.Data, componentName)
-			rDataMap := actionTemplateResourceDataMap["data"].(map[string]interface{})
-			var cluster int = int(rDataMap["_cluster"].(float64))
+
+			// if scaling is disabled in the blueprint we get an empty "data" field, in that case we assume cluster value to be "1"
+			var rDataMap map[string]interface{}
+			var cluster int
+			if actionTemplateResourceDataMap["data"] != nil {
+				rDataMap = actionTemplateResourceDataMap["data"].(map[string]interface{})
+				cluster = int(rDataMap["_cluster"].(float64))
+			} else {
+				cluster = 1
+			}
 			resourceConfigStruct.Cluster = cluster
 			// end
 

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -440,8 +440,16 @@ func resourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) error 
 			scaleOutActionID := deploymentActionsMap["Scale Out"]
 			resourceActionTemplate, _ := vraClient.GetResourceActionTemplate(parentResourceID, scaleOutActionID)
 			actionTemplateResourceDataMap := GetActionTemplateDataByComponent(resourceActionTemplate.Data, componentName)
-			rDataMap := actionTemplateResourceDataMap["data"].(map[string]interface{})
-			var cluster int = int(rDataMap["_cluster"].(float64))
+
+			// if scaling is disabled in the blueprint we get an empty "data" field, in that case we assume cluster value to be "1"
+			var rDataMap map[string]interface{}
+			var cluster int
+			if actionTemplateResourceDataMap["data"] != nil {
+				rDataMap = actionTemplateResourceDataMap["data"].(map[string]interface{})
+				cluster = int(rDataMap["_cluster"].(float64))
+			} else {
+				cluster = 1
+			}
 			resourceConfigStruct.Cluster = cluster
 			// end
 


### PR DESCRIPTION
If scaling is disabled in a blueprint the `data` field of the scale out action template response is empty, causing the data source and also the resource creation to fail with a provider crash with a panic because of the interface being nil.

This PR checks for that and sets `cluster` to a fixed value of `1` in this case, which should be fine as with disabled scaling in a blueprint cluster size can only be `1`.

Fixes #59 

I hope this way of doing it is feasible for use in the provider.