### PR TITLE
[WIP] Suppress diff for `configuration` items in case they are not set

### DIFF
--- a/vra7/resource_configuration.go
+++ b/vra7/resource_configuration.go
@@ -11,7 +11,7 @@ import (
 
 func resourceConfigurationSchema(computed bool) *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Optional: !computed,
 		Computed: computed,
 		Elem: &schema.Resource{
@@ -25,6 +25,12 @@ func resourceConfigurationSchema(computed bool) *schema.Schema {
 					Type:     schema.TypeMap,
 					Optional: true,
 					Computed: true,
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						if old != "" && new == "" {
+							return true
+						}
+						return false
+					},
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
 					},

--- a/vra7/resource_configuration.go
+++ b/vra7/resource_configuration.go
@@ -26,7 +26,7 @@ func resourceConfigurationSchema(computed bool) *schema.Schema {
 					Optional: true,
 					Computed: true,
 					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-						if old != "" && new == "" {
+						if (old != "" && new == "") || (old == "" && new == "") {
 							return true
 						}
 						return false
@@ -89,10 +89,10 @@ func resourceConfigurationSchema(computed bool) *schema.Schema {
 	}
 }
 
-func expandResourceConfiguration(rConfigurations []interface{}) []sdk.ResourceConfigurationStruct {
-	configs := make([]sdk.ResourceConfigurationStruct, 0, len(rConfigurations))
+func expandResourceConfiguration(rConfigurations interface{}) []sdk.ResourceConfigurationStruct {
+	configs := make([]sdk.ResourceConfigurationStruct, 0, len(rConfigurations.([]interface{})))
 
-	for _, config := range rConfigurations {
+	for _, config := range rConfigurations.([]interface{}) {
 		configMap := config.(map[string]interface{})
 
 		rConfig := sdk.ResourceConfigurationStruct{

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -266,8 +266,8 @@ func resourceVra7DeploymentUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	// get the old and new resource_configuration data
 	old, new := d.GetChange("resource_configuration")
-	oldResourceConfigList := expandResourceConfiguration(old.(*schema.Set).List())
-	newResourceConfigList := expandResourceConfiguration(new.(*schema.Set).List())
+	oldResourceConfigList := expandResourceConfiguration(old)
+	newResourceConfigList := expandResourceConfiguration(new)
 
 	if d.HasChange("resource_configuration") {
 		for _, newResourceConfig := range newResourceConfigList {
@@ -603,7 +603,7 @@ func readProviderConfiguration(d *schema.ResourceData, vraClient *sdk.APIClient)
 		Lease:                   d.Get("lease_days").(int),
 		DeploymentID:            strings.TrimSpace(d.Get("deployment_id").(string)),
 		WaitTimeout:             d.Get("wait_timeout").(int) * 60,
-		ResourceConfiguration:   expandResourceConfiguration(d.Get("resource_configuration").(*schema.Set).List()),
+		ResourceConfiguration:   expandResourceConfiguration(d.Get("resource_configuration")),
 		DeploymentDestroy:       d.Get("deployment_destroy").(bool),
 		DeploymentConfiguration: d.Get("deployment_configuration").(map[string]interface{}),
 	}


### PR DESCRIPTION
When there is a Deployment with resource configurations for VMs that contain more or different custom properties within the `configuration` map, each time when `terraform plan` is run, there is a diff produced that completely removes the `configuration` block within `resource_configuration` and adds a new one with only the values provided in the `vra7_deployment` TF resource.

This seems to be because `resource_configuration` is a `TypeSet` in the Resource Schema. 

That means, each time the hash calculated from the settings in the state is not identical to the one in the resource config, Terraform treats it as a different `resource_configuration` and wants to remove the existing block from the state and put in only the values in the config.

For this, I propose to change this to `TypeList`. However, this would depend on the vRA7 API returning the `content[]` in the `ResourceView` response always in the same order (which I'm not 100 % sure of right now).

After changing the Type to List, we also add a `DiffSuppressFunc` to the `configuration` Element that checks if a custom property from the state needs to be included in the diff. 

If it set in the state, but NOT in the resource config, we ignore the diff. This is because often there are quite a lot of custom properties returned for a VM that are set on vRA side and are not of interest to the resource configuration in the first place.

Aims to fix #56 