### PR TITLE
read resource_configuration also from deployments with non-VM resources

### DIFF
--- a/sdk/vra7_sdk.go
+++ b/sdk/vra7_sdk.go
@@ -191,6 +191,20 @@ func (c *APIClient) GetRequestResourceView(catalogRequestID string) (*RequestRes
 	return &response, nil
 }
 
+// GetChildResources retrieves the resources that were provisioned as a result of a given request.
+func (c *APIClient) GetChildResources(link string) (*RequestResourceView, error) {
+	resp, respErr := c.Get(link, nil)
+	if respErr != nil {
+		return nil, respErr
+	}
+	var response RequestResourceView
+	unmarshallErr := utils.UnmarshalJSON(resp.Body, &response)
+	if unmarshallErr != nil {
+		return nil, unmarshallErr
+	}
+	return &response, nil
+}
+
 // RequestCatalogItem - Make a catalog request.
 func (c *APIClient) RequestCatalogItem(requestTemplate *CatalogItemRequestTemplate) (*CatalogRequest, error) {
 	//Form a path to set a REST call to create a machine

--- a/vra7/data_source_vra7_deployment.go
+++ b/vra7/data_source_vra7_deployment.go
@@ -186,13 +186,10 @@ func dataSourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) erro
 					dateCreated := rMap["dateCreated"].(string)
 					lastUpdated := rMap["lastUpdated"].(string)
 					resourceID := rMap["resourceId"].(string)
-					// if the resource type is VMs, update the resource_configuration attribute
 					data := rMap["data"].(map[string]interface{})
-					// componentName := data["Component"].(string)
 					parentResourceID := rMap["parentResourceId"].(string)
 					var resourceConfigStruct sdk.ResourceConfigurationStruct
 					resourceConfigStruct.Configuration = data
-					// resourceConfigStruct.ComponentName = componentName
 					resourceConfigStruct.Name = name
 					resourceConfigStruct.DateCreated = dateCreated
 					resourceConfigStruct.LastUpdated = lastUpdated
@@ -202,7 +199,13 @@ func dataSourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) erro
 					resourceConfigStruct.RequestState = requestState
 					resourceConfigStruct.ParentResourceID = parentResourceID
 					if resourceType == sdk.InfrastructureVirtual {
+						componentName := data["Component"].(string)
+						resourceConfigStruct.ComponentName = componentName
 						resourceConfigStruct.IPAddress = data["ip_address"].(string)
+
+						// the cluster value is calculated from the map based on the component name as the
+						// resourceViews API does not return that information
+						clusterCountMap[componentName] = clusterCountMap[componentName] + 1
 					}
 
 					if rMap["description"] != nil {
@@ -211,9 +214,6 @@ func dataSourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) erro
 					if rMap["status"] != nil {
 						resourceConfigStruct.Status = rMap["status"].(string)
 					}
-					// the cluster value is calculated from the map based on the component name as the
-					// resourceViews API does not return that information
-					// clusterCountMap[componentName] = clusterCountMap[componentName] + 1
 
 					resourceConfigList = append(resourceConfigList, resourceConfigStruct)
 				}

--- a/vra7/data_source_vra7_deployment.go
+++ b/vra7/data_source_vra7_deployment.go
@@ -126,38 +126,11 @@ func dataSourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) erro
 		resourceID := rMap["resourceId"].(string)
 		requestID := rMap["requestId"].(string)
 		requestState := rMap["requestState"].(string)
+		hasChildren := rMap["hasChildren"].(bool)
 
-		// if the resource type is VMs, update the resource_configuration attribute
-		if resourceType == sdk.InfrastructureVirtual {
-			data := rMap["data"].(map[string]interface{})
-			componentName := data["Component"].(string)
-			parentResourceID := rMap["parentResourceId"].(string)
-			var resourceConfigStruct sdk.ResourceConfigurationStruct
-			resourceConfigStruct.Configuration = data
-			resourceConfigStruct.ComponentName = componentName
-			resourceConfigStruct.Name = name
-			resourceConfigStruct.DateCreated = dateCreated
-			resourceConfigStruct.LastUpdated = lastUpdated
-			resourceConfigStruct.ResourceID = resourceID
-			resourceConfigStruct.ResourceType = resourceType
-			resourceConfigStruct.RequestID = requestID
-			resourceConfigStruct.RequestState = requestState
-			resourceConfigStruct.ParentResourceID = parentResourceID
-			resourceConfigStruct.IPAddress = data["ip_address"].(string)
-
-			if rMap["description"] != nil {
-				resourceConfigStruct.Description = rMap["description"].(string)
-			}
-			if rMap["status"] != nil {
-				resourceConfigStruct.Status = rMap["status"].(string)
-			}
-			// the cluster value is calculated from the map based on the component name as the
-			// resourceViews API does not return that information
-			clusterCountMap[componentName] = clusterCountMap[componentName] + 1
-
-			resourceConfigList = append(resourceConfigList, resourceConfigStruct)
-
-		} else if resourceType == sdk.DeploymentResourceType {
+		// only read the Deployment from the first content response,
+		// get VMs and other components as Child Resources from the Deployment
+		if resourceType == sdk.DeploymentResourceType {
 
 			leaseMap := rMap["lease"].(map[string]interface{})
 			leaseStart := leaseMap["start"].(string)
@@ -185,6 +158,68 @@ func dataSourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) erro
 			d.Set("owners", rMap["owners"].([]interface{}))
 			d.Set("name", name)
 			d.Set("businessgroup_id", rMap["businessGroupId"].(string))
+
+			if hasChildren {
+				links := rMap["links"].([]interface{})
+				var childResourcesLink string
+
+				for _, link := range links {
+					l := link.(map[string]interface{})
+					if l["rel"].(string) == "GET: Child Resources" {
+						childResourcesLink = l["href"].(string)
+					}
+				}
+				requestResourceView, errTemplate := vraClient.GetChildResources(childResourcesLink)
+				if requestResourceView != nil && len(requestResourceView.Content) == 0 {
+					//If resource does not exists then unset the resource ID from state file
+					d.SetId("")
+					return fmt.Errorf("The resource cannot be found")
+				}
+				if errTemplate != nil || len(requestResourceView.Content) == 0 {
+					return fmt.Errorf("Resource view failed to load with the error %v", errTemplate)
+				}
+
+				for _, resource := range requestResourceView.Content {
+					rMap := resource.(map[string]interface{})
+					resourceType := rMap["resourceType"].(string)
+					name := rMap["name"].(string)
+					dateCreated := rMap["dateCreated"].(string)
+					lastUpdated := rMap["lastUpdated"].(string)
+					resourceID := rMap["resourceId"].(string)
+					// if the resource type is VMs, update the resource_configuration attribute
+					data := rMap["data"].(map[string]interface{})
+					// componentName := data["Component"].(string)
+					parentResourceID := rMap["parentResourceId"].(string)
+					var resourceConfigStruct sdk.ResourceConfigurationStruct
+					resourceConfigStruct.Configuration = data
+					// resourceConfigStruct.ComponentName = componentName
+					resourceConfigStruct.Name = name
+					resourceConfigStruct.DateCreated = dateCreated
+					resourceConfigStruct.LastUpdated = lastUpdated
+					resourceConfigStruct.ResourceID = resourceID
+					resourceConfigStruct.ResourceType = resourceType
+					resourceConfigStruct.RequestID = requestID
+					resourceConfigStruct.RequestState = requestState
+					resourceConfigStruct.ParentResourceID = parentResourceID
+					if resourceType == sdk.InfrastructureVirtual {
+						resourceConfigStruct.IPAddress = data["ip_address"].(string)
+					}
+
+					if rMap["description"] != nil {
+						resourceConfigStruct.Description = rMap["description"].(string)
+					}
+					if rMap["status"] != nil {
+						resourceConfigStruct.Status = rMap["status"].(string)
+					}
+					// the cluster value is calculated from the map based on the component name as the
+					// resourceViews API does not return that information
+					// clusterCountMap[componentName] = clusterCountMap[componentName] + 1
+
+					resourceConfigList = append(resourceConfigList, resourceConfigStruct)
+				}
+
+			}
+
 			if rMap["description"] != nil {
 				d.Set("description", rMap["description"].(string))
 			}

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -414,37 +414,11 @@ func resourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) error 
 		resourceID := rMap["resourceId"].(string)
 		requestID := rMap["requestId"].(string)
 		requestState := rMap["requestState"].(string)
+		hasChildren := rMap["hasChildren"].(bool)
 
-		// if the resource type is VMs, update the resource_configuration attribute
-		if resourceType == sdk.InfrastructureVirtual {
-			data := rMap["data"].(map[string]interface{})
-			componentName := data["Component"].(string)
-			parentResourceID := rMap["parentResourceId"].(string)
-			var resourceConfigStruct sdk.ResourceConfigurationStruct
-			resourceConfigStruct.Configuration = data
-			resourceConfigStruct.ComponentName = componentName
-			resourceConfigStruct.Name = name
-			resourceConfigStruct.DateCreated = dateCreated
-			resourceConfigStruct.LastUpdated = lastUpdated
-			resourceConfigStruct.ResourceID = resourceID
-			resourceConfigStruct.ResourceType = resourceType
-			resourceConfigStruct.RequestID = requestID
-			resourceConfigStruct.RequestState = requestState
-			resourceConfigStruct.ParentResourceID = parentResourceID
-			resourceConfigStruct.IPAddress = data["ip_address"].(string)
-
-			if rMap["description"] != nil {
-				resourceConfigStruct.Description = rMap["description"].(string)
-			}
-			if rMap["status"] != nil {
-				resourceConfigStruct.Status = rMap["status"].(string)
-			}
-			// the cluster value is calculated from the map based on the component name as the
-			// resourceViews API does not return that information
-			clusterCountMap[componentName] = clusterCountMap[componentName] + 1
-			resourceConfigList = append(resourceConfigList, resourceConfigStruct)
-
-		} else if resourceType == sdk.DeploymentResourceType {
+		// only read the Deployment from the first content response,
+		// get VMs and other components as Child Resources from the Deployment
+		if resourceType == sdk.DeploymentResourceType {
 
 			leaseMap := rMap["lease"].(map[string]interface{})
 			leaseStart := leaseMap["start"].(string)
@@ -472,6 +446,68 @@ func resourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) error 
 			d.Set("owners", rMap["owners"].([]interface{}))
 			d.Set("name", name)
 			d.Set("businessgroup_id", rMap["businessGroupId"].(string))
+
+			if hasChildren {
+				links := rMap["links"].([]interface{})
+				var childResourcesLink string
+
+				for _, link := range links {
+					l := link.(map[string]interface{})
+					if l["rel"].(string) == "GET: Child Resources" {
+						childResourcesLink = l["href"].(string)
+					}
+				}
+				requestResourceView, errTemplate := vraClient.GetChildResources(childResourcesLink)
+				if requestResourceView != nil && len(requestResourceView.Content) == 0 {
+					//If resource does not exists then unset the resource ID from state file
+					d.SetId("")
+					return fmt.Errorf("The resource cannot be found")
+				}
+				if errTemplate != nil || len(requestResourceView.Content) == 0 {
+					return fmt.Errorf("Resource view failed to load with the error %v", errTemplate)
+				}
+
+				for _, resource := range requestResourceView.Content {
+					rMap := resource.(map[string]interface{})
+					resourceType := rMap["resourceType"].(string)
+					name := rMap["name"].(string)
+					dateCreated := rMap["dateCreated"].(string)
+					lastUpdated := rMap["lastUpdated"].(string)
+					resourceID := rMap["resourceId"].(string)
+					// if the resource type is VMs, update the resource_configuration attribute
+					data := rMap["data"].(map[string]interface{})
+					// componentName := data["Component"].(string)
+					parentResourceID := rMap["parentResourceId"].(string)
+					var resourceConfigStruct sdk.ResourceConfigurationStruct
+					resourceConfigStruct.Configuration = data
+					// resourceConfigStruct.ComponentName = componentName
+					resourceConfigStruct.Name = name
+					resourceConfigStruct.DateCreated = dateCreated
+					resourceConfigStruct.LastUpdated = lastUpdated
+					resourceConfigStruct.ResourceID = resourceID
+					resourceConfigStruct.ResourceType = resourceType
+					resourceConfigStruct.RequestID = requestID
+					resourceConfigStruct.RequestState = requestState
+					resourceConfigStruct.ParentResourceID = parentResourceID
+					if resourceType == sdk.InfrastructureVirtual {
+						resourceConfigStruct.IPAddress = data["ip_address"].(string)
+					}
+
+					if rMap["description"] != nil {
+						resourceConfigStruct.Description = rMap["description"].(string)
+					}
+					if rMap["status"] != nil {
+						resourceConfigStruct.Status = rMap["status"].(string)
+					}
+					// the cluster value is calculated from the map based on the component name as the
+					// resourceViews API does not return that information
+					// clusterCountMap[componentName] = clusterCountMap[componentName] + 1
+
+					resourceConfigList = append(resourceConfigList, resourceConfigStruct)
+				}
+
+			}
+
 			if rMap["description"] != nil {
 				d.Set("description", rMap["description"].(string))
 			}

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -474,13 +474,10 @@ func resourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) error 
 					dateCreated := rMap["dateCreated"].(string)
 					lastUpdated := rMap["lastUpdated"].(string)
 					resourceID := rMap["resourceId"].(string)
-					// if the resource type is VMs, update the resource_configuration attribute
 					data := rMap["data"].(map[string]interface{})
-					// componentName := data["Component"].(string)
 					parentResourceID := rMap["parentResourceId"].(string)
 					var resourceConfigStruct sdk.ResourceConfigurationStruct
 					resourceConfigStruct.Configuration = data
-					// resourceConfigStruct.ComponentName = componentName
 					resourceConfigStruct.Name = name
 					resourceConfigStruct.DateCreated = dateCreated
 					resourceConfigStruct.LastUpdated = lastUpdated
@@ -490,7 +487,13 @@ func resourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) error 
 					resourceConfigStruct.RequestState = requestState
 					resourceConfigStruct.ParentResourceID = parentResourceID
 					if resourceType == sdk.InfrastructureVirtual {
+						componentName := data["Component"].(string)
+						resourceConfigStruct.ComponentName = componentName
 						resourceConfigStruct.IPAddress = data["ip_address"].(string)
+
+						// the cluster value is calculated from the map based on the component name as the
+						// resourceViews API does not return that information
+						clusterCountMap[componentName] = clusterCountMap[componentName] + 1
 					}
 
 					if rMap["description"] != nil {
@@ -499,10 +502,6 @@ func resourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) error 
 					if rMap["status"] != nil {
 						resourceConfigStruct.Status = rMap["status"].(string)
 					}
-					// the cluster value is calculated from the map based on the component name as the
-					// resourceViews API does not return that information
-					// clusterCountMap[componentName] = clusterCountMap[componentName] + 1
-
 					resourceConfigList = append(resourceConfigList, resourceConfigStruct)
 				}
 


### PR DESCRIPTION
Signed-off-by: Marcel Juhnke <marcel.juhnke@gfk.com>

This PR changes the way how `resource_configuration` is read back from a vRA Deployment into the state file.

Previously, only the data of vSphere VMs (resource type `Infrastructure.Virtual`) has been read back into the state files `resource_configuration` block. All non-VM resources in a deployment have been ignored in the state file. 

This was also because the vRA API sends back the VM resources in a deployment directly in the ResourceView response, whereas for custom resource types only the Deployment itself would get sent back with a link to its Child Resources.

So this PR changes the logic on how Deployment details are read.

At first, only the Deployment itself is processed and then the `GET: Child Resources` link in the response is used to retrieve all child resources (which then includes both VMs and non-VM resources).

Those child resources then are added into the `resource_configuration` set, no matter if they are a VM or not (and including the IP address just for VMs, of course).

This implements #68 