### PR TITLE
[80] Output missing when relying on defaults for resource_configuration

### DIFF
--- a/vra7/data_source_vra7_deployment.go
+++ b/vra7/data_source_vra7_deployment.go
@@ -46,7 +46,7 @@ func dataSourceVra7Deployment() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"resource_configuration": resourceConfigurationSchema(true),
+			"resource_configuration": resourceConfigurationSchema(false),
 			"lease_days": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/vra7/resource_configuration.go
+++ b/vra7/resource_configuration.go
@@ -9,21 +9,21 @@ import (
 	"github.com/vmware/terraform-provider-vra7/utils"
 )
 
-func resourceConfigurationSchema(computed bool) *schema.Schema {
+func resourceConfigurationSchema(optional bool) *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
-		Optional: !computed,
-		Computed: computed,
+		Optional: optional,
+		Computed: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"component_name": {
 					Type:     schema.TypeString,
-					Required: !computed,
-					Computed: computed,
+					Optional: optional,
+					Computed: true,
 				},
 				"configuration": {
 					Type:     schema.TypeMap,
-					Optional: true,
+					Optional: optional,
 					Computed: true,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
@@ -31,7 +31,7 @@ func resourceConfigurationSchema(computed bool) *schema.Schema {
 				},
 				"cluster": {
 					Type:     schema.TypeInt,
-					Optional: true,
+					Optional: optional,
 					Computed: true,
 				},
 				"resource_id": {

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -91,7 +91,7 @@ func resourceVra7Deployment() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
-			"resource_configuration": resourceConfigurationSchema(false),
+			"resource_configuration": resourceConfigurationSchema(true),
 			"lease_days": {
 				Type:     schema.TypeInt,
 				Computed: true,


### PR DESCRIPTION
Fix for https://github.com/vmware/terraform-provider-vra7/issues/80
The state file will be updated with the resource_configuration block
even if it is not specified in the tf config file

Signed-off-by: Prativa Bawri <bawrip@vmware.com>