### PR TITLE
[issue 73] Issue with Terraform PLAN

### DIFF
--- a/sdk/schema.go
+++ b/sdk/schema.go
@@ -16,6 +16,7 @@ type ResourceConfigurationStruct struct {
 	RequestState     string                 `json:"request_state,omitempty"`
 	ResourceType     string                 `json:"resource_type,omitempty"`
 	Configuration    map[string]interface{} `json:"configuration,omitempty"`
+	ResourceState    map[string]interface{} `json:"resource_state,omitempty"`
 	DateCreated      string                 `json:"last_created,omitempty"`
 	LastUpdated      string                 `json:"last_updated,omitempty"`
 	ParentResourceID string                 `json:"parent_resource_id,omitempty"`

--- a/utils/utilities.go
+++ b/utils/utilities.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"reflect"
 	"strconv"
-	"strings"
 
 	"github.com/op/go-logging"
 )
@@ -76,83 +75,4 @@ func UnmarshalJSONStringIfNecessary(field string, value interface{}) interface{}
 	}
 
 	return jsonValue
-}
-
-// UpdateResourceConfigurationMap updates the resource configuration with
-//the deployment resource data if there is difference
-// between the config data and deployment data, return true
-func UpdateResourceConfigurationMap(
-	resourceConfiguration map[string]interface{}, vmData map[string]map[string]interface{}) (map[string]interface{}, bool) {
-	var changed bool
-	for configKey1, configValue1 := range resourceConfiguration {
-		for configKey2, configValue2 := range vmData {
-			if strings.HasPrefix(configKey1, configKey2+".") {
-				trimmedKey := strings.TrimPrefix(configKey1, configKey2+".")
-				currentValue := configValue1
-				updatedValue := ConvertInterfaceToString(configValue2[trimmedKey])
-
-				if updatedValue != "" && updatedValue != currentValue {
-					resourceConfiguration[configKey1] = updatedValue
-					changed = true
-				}
-			}
-		}
-	}
-	return resourceConfiguration, changed
-}
-
-// ReplaceValueInRequestTemplate replaces the value for a given key in a catalog
-// request template.
-func ReplaceValueInRequestTemplate(templateInterface map[string]interface{}, field string, value interface{}) bool {
-	var replaced bool
-	//Iterate over the map to get field provided as an argument
-	for key, val := range templateInterface {
-		//If value type is map then set recursive call which will fiend field in one level down of map interface
-		if reflect.ValueOf(val).Kind() == reflect.Map {
-			replaced = ReplaceValueInRequestTemplate(val.(map[string]interface{}), field, value)
-			if replaced {
-				return true
-			}
-		} else if key == field && val != value {
-			//If value type is not map then compare field name with provided field name
-			//If both matches then update field value with provided value
-			templateInterface[key] = value
-			if reflect.ValueOf(value).Kind() == reflect.String {
-				templateInterface[key] = UnmarshalJSONStringIfNecessary(field, value)
-			}
-			return true
-		}
-	}
-	return replaced
-}
-
-// AddValueToRequestTemplate modeled after replaceValueInRequestTemplate
-// for values being added to template vs updating existing ones
-func AddValueToRequestTemplate(templateInterface map[string]interface{}, field string, value interface{}) map[string]interface{} {
-	//simplest case is adding a simple value. Leaving as a func in case there's a need to do more complicated additions later
-	//	templateInterface[data]
-	for k, v := range templateInterface {
-		if reflect.ValueOf(v).Kind() == reflect.Map && k == "data" {
-			template, _ := v.(map[string]interface{})
-			_ = AddValueToRequestTemplate(template, field, value)
-		} else { //if i == "data" {
-			templateInterface[field] = UnmarshalJSONStringIfNecessary(field, value)
-		}
-	}
-	//Return updated map interface type
-	return templateInterface
-}
-
-// ResourceMapper returns the mapping of resource attributes from ResourceView APIs
-// to Catalog Item Request Template APIs
-func ResourceMapper() map[string]string {
-	m := make(map[string]string)
-	m["MachineName"] = "name"
-	m["MachineDescription"] = "description"
-	m["MachineMemory"] = "memory"
-	m["MachineStorage"] = "storage"
-	m["MachineCPU"] = "cpu"
-	m["MachineStatus"] = "status"
-	m["MachineType"] = "type"
-	return m
 }

--- a/vra7/data_source_vra7_deployment.go
+++ b/vra7/data_source_vra7_deployment.go
@@ -133,7 +133,7 @@ func dataSourceVra7DeploymentRead(d *schema.ResourceData, meta interface{}) erro
 			componentName := data["Component"].(string)
 			parentResourceID := rMap["parentResourceId"].(string)
 			var resourceConfigStruct sdk.ResourceConfigurationStruct
-			resourceConfigStruct.Configuration = data
+			resourceConfigStruct.ResourceState = data
 			resourceConfigStruct.ComponentName = componentName
 			resourceConfigStruct.Name = name
 			resourceConfigStruct.DateCreated = dateCreated

--- a/vra7/utils.go
+++ b/vra7/utils.go
@@ -1,0 +1,99 @@
+package vra7
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/vmware/terraform-provider-vra7/sdk"
+	"github.com/vmware/terraform-provider-vra7/utils"
+)
+
+// UpdateResourceConfigurationMap updates the resource configuration with
+//the deployment resource data if there is difference
+// between the config data and deployment data, return true
+func UpdateResourceConfigurationMap(
+	resourceConfiguration map[string]interface{}, vmData map[string]map[string]interface{}) (map[string]interface{}, bool) {
+	var changed bool
+	for configKey1, configValue1 := range resourceConfiguration {
+		for configKey2, configValue2 := range vmData {
+			if strings.HasPrefix(configKey1, configKey2+".") {
+				trimmedKey := strings.TrimPrefix(configKey1, configKey2+".")
+				currentValue := configValue1
+				updatedValue := utils.ConvertInterfaceToString(configValue2[trimmedKey])
+
+				if updatedValue != "" && updatedValue != currentValue {
+					resourceConfiguration[configKey1] = updatedValue
+					changed = true
+				}
+			}
+		}
+	}
+	return resourceConfiguration, changed
+}
+
+// ReplaceValueInRequestTemplate replaces the value for a given key in a catalog
+// request template.
+func ReplaceValueInRequestTemplate(templateInterface map[string]interface{}, field string, value interface{}) bool {
+	var replaced bool
+	//Iterate over the map to get field provided as an argument
+	for key, val := range templateInterface {
+		//If value type is map then set recursive call which will fiend field in one level down of map interface
+		if reflect.ValueOf(val).Kind() == reflect.Map {
+			replaced = ReplaceValueInRequestTemplate(val.(map[string]interface{}), field, value)
+			if replaced {
+				return true
+			}
+		} else if key == field && val != value {
+			//If value type is not map then compare field name with provided field name
+			//If both matches then update field value with provided value
+			templateInterface[key] = value
+			if reflect.ValueOf(value).Kind() == reflect.String {
+				templateInterface[key] = utils.UnmarshalJSONStringIfNecessary(field, value)
+			}
+			return true
+		}
+	}
+	return replaced
+}
+
+// AddValueToRequestTemplate modeled after replaceValueInRequestTemplate
+// for values being added to template vs updating existing ones
+func AddValueToRequestTemplate(templateInterface map[string]interface{}, field string, value interface{}) map[string]interface{} {
+	//simplest case is adding a simple value. Leaving as a func in case there's a need to do more complicated additions later
+	//	templateInterface[data]
+	for k, v := range templateInterface {
+		if reflect.ValueOf(v).Kind() == reflect.Map && k == "data" {
+			template, _ := v.(map[string]interface{})
+			_ = AddValueToRequestTemplate(template, field, value)
+		} else { //if i == "data" {
+			templateInterface[field] = utils.UnmarshalJSONStringIfNecessary(field, value)
+		}
+	}
+	//Return updated map interface type
+	return templateInterface
+}
+
+// ResourceMapper returns the mapping of resource attributes from ResourceView APIs
+// to Catalog Item Request Template APIs
+func ResourceMapper() map[string]string {
+	m := make(map[string]string)
+	m["MachineName"] = "name"
+	m["MachineDescription"] = "description"
+	m["MachineMemory"] = "memory"
+	m["MachineStorage"] = "storage"
+	m["MachineCPU"] = "cpu"
+	m["MachineStatus"] = "status"
+	m["MachineType"] = "type"
+	return m
+}
+
+// GetConfiguration returns the configuration property for the componentName from the resource_configuration provided in the .tf file
+func GetConfiguration(componentName string, resourceConfiguration []sdk.ResourceConfigurationStruct) map[string]interface{} {
+	m := make(map[string]interface{})
+	for _, elem := range resourceConfiguration {
+		if elem.ComponentName == componentName {
+			m = elem.Configuration
+		}
+	}
+	return m
+}

--- a/website/docs/d/vra7_deployment.html.markdown
+++ b/website/docs/d/vra7_deployment.html.markdown
@@ -64,7 +64,7 @@ The following arguments for resource_configuration block are supported:
 #### Attribute Reference
 
 * `component_name` - The name of the component/machine resource as in the blueprint/catalog_item
-* `configuration` - The machine resource level properties like cpu, memory, storage, custom properties, etc. can be added here. When fetching the state of the machine, this will be populated with a lot of information in the state file.
+* `resource_state` - The detailed state/view of the machine resources within the deployment
 * `cluster` - Cluster size for this machine resource
 * `resource_id` - ID of the machine resource
 * `name` - Name of the resource

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -102,6 +102,7 @@ NOTE: To add an array property, refer to the security_tag value in example above
 * `resource_id` - ID of the machine resource
 * `name` - Name of the resource
 * `description` - Description of the resource
+* `resource_state` - The detailed state/view of the machine resources within the deployment
 * `parent_resource_id` - ID of the deployment of which this machine is a part of
 * `ip_address` - IP address of the machine
 * `request_id` - ID of the catalog item request


### PR DESCRIPTION
Plan was showing a diff even if nothing was changed in the .tf file
Fixing this issue by introducing another property in the resource_configuration called `resource_state`. 
`resource_state` is a computed property. To create or update the deployment, modify the `configuration` property and the updated state will be populated in the `resource_state`

**NOTE:** If you using terraform output to read machine properties from the configuration block, you will have to modify that to use resource_state

For example, the following needs to be modified as

```
output "test" {                                                                                                                                                                                       
   value = vra7_deployment.this[*].resource_configuration[*].configuration.storage                     
}
```

```
output "test" {                                                                                                                                                                                       
   value = vra7_deployment.this[*].resource_configuration[*].resource_state.storage                     
}
```


Signed-off-by: Prativa Bawri <bawrip@vmware.com>