### PR TITLE
[73] Issue with Terraform PLAN

### DIFF
--- a/vra7/utils.go
+++ b/vra7/utils.go
@@ -97,3 +97,18 @@ func GetConfiguration(componentName string, resourceConfiguration []sdk.Resource
 	}
 	return m
 }
+
+// ConvertToDateTime converts ISO8601 (2020-04-16T00:15:00.700Z) returned from vRA to YYYY-MM-DD HH:MM format
+func ConvertToDateTime(inputFormat string) string {
+	s := strings.Split(inputFormat, "T")
+	return s[0] + " " + s[1][0:5]
+}
+
+// ConvertToISO8601 converts lease_end to the format ISO8601 (2020-04-16T00:15:00.700Z) that vRA 7.x understands
+func ConvertToISO8601(givenTime string) string {
+	s := strings.Split(givenTime, " ")
+	if len(s) == 1 {
+		return s[0] + "T" + "00:00" + ":00.700Z"
+	}
+	return s[0] + "T" + s[1] + ":00.700Z"
+}

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -67,7 +67,8 @@ The following arguments are supported:
 * `reasons` - (Optional) Reasons for requesting the deployment.
 * `deployment_configuration` - (Optional) The configuration of the deployment from the catalog item. All blueprint custom properties including property groups can be added to this block. This property is discussed in detail below.
 * `resource_configuration` - (Optional) The configuration of the individual components from the catalog item. This property is discussed in detail below.
-* `lease_days` - (Optional) Number of lease days remaining for the deployment. NOTE: lease_days 0 means the lease never expires.
+* `lease_days` - (Optional) Number of lease days when creating the deployment resource for the first time. NOTE: lease_days 0 means the lease never expires.
+* `lease_end` - (Optional) End date of the lease in YYYY-MM-DD HH:MM or YYYY-MM-DD format in GMT time zone. It accepts time in 24 hour clock format. To update the lease expiration time, update lease_end and not lease_days.
 * `wait_timeout` - (Optional) Wait time out for the request. If the request is not completed within the timeout period, do a terraform refresh later to check the status of the request. 
 
 ## Attribute Reference
@@ -75,7 +76,6 @@ The following arguments are supported:
 * `deployment_id` - The resource id of the deployment.
 * `name` - The name of the deployment.
 * `lease_start` - Start date of the lease.
-* `lease_end` - End date of the lease.
 * `request_status` - The status of the catalog item request.
 * `date_created` - The date when the deployment was created.
 * `last_updated` - The date when the deployment was last updated after Day 2 operations.


### PR DESCRIPTION
One of the reason for issue in terraform plan is the lease_days.
When creating deployment resource with lease_days(say, 10), the state file is updated with
lease_days 9(this is calculated from lease_end - lease start time). In the following iterations, even
if nothing changes in the config file, the plan always detects a change as state file has lease_days 9
and config has 10.

Fixing this by mimicing the same behavior as in the vRA UI.

`lease_days` will be used to specify the number of lease days only when the deployment is created the
first time. The `lease_end` and `lease_start` will be computed and updated in the state file.
Any update of the property lease_days will be ignored.
To update the lease, use `lease_end` property. Specify in the YYYY-MM-DD HH:MM format.

Signed-off-by: Prativa Bawri <bawrip@vmware.com>