### PR TITLE
Added Encoding For Query Params From Server URL

### DIFF
--- a/sdk/client_utils.go
+++ b/sdk/client_utils.go
@@ -140,7 +140,11 @@ func (c *APIClient) BuildEncodedURL(relativePath string, queryParameters map[str
 
 	queryURL.Path += relativePath
 
-	parameters := url.Values{}
+	parameters, err := url.ParseQuery(queryURL.RawQuery)
+	if err != nil {
+		log.Error("Error %v ", err)
+	}
+
 	if queryParameters != nil {
 		for key, value := range queryParameters {
 			parameters.Add(key, value)

--- a/sdk/vra7_client.go
+++ b/sdk/vra7_client.go
@@ -59,7 +59,7 @@ func (c *APIClient) DoRequest(req *APIRequest, login bool) (*APIResponse, error)
 
 // Authenticate authenticates for the first time when the provider is invoked
 func (c *APIClient) Authenticate() error {
-	uri := fmt.Sprintf(AuthenticationIdentityTokenAPI, c.BaseURL)
+	uri := c.BuildEncodedURL(Tokens, nil)
 	data := AuthenticationRequest{
 		Username: c.Username,
 		Password: c.Password,


### PR DESCRIPTION
BuildEncodedURL function respects query params
set for `host` value in provider configuration.

It was tested with VRA 7.5 and is necessary in our setup as we are using API geteway requireing extra url params.

Signed-off-by: Przemyslaw Swierczek <swierq@gmail.com>

