### PR TITLE
[Issue-103]Unneccesary lookup of BusinessGroupId via Identity API

### DIFF
--- a/sdk/vra7_sdk.go
+++ b/sdk/vra7_sdk.go
@@ -145,6 +145,22 @@ func (c *APIClient) GetBusinessGroupID(businessGroupName string, tenant string) 
 	if unmarshallErr != nil {
 		return "", unmarshallErr
 	}
+
+	if len(businessGroups.Content) == 0 {
+		path = path + "/membership"
+
+		membershipURL := c.BuildEncodedURL(path, nil)
+
+		resp, respErr := c.Get(membershipURL, nil)
+		if respErr != nil {
+			return "", respErr
+		}
+		unmarshallErr := utils.UnmarshalJSON(resp.Body, &businessGroups)
+		if unmarshallErr != nil {
+			return "", unmarshallErr
+		}
+	}
+
 	// BusinessGroups array will contain only one BusinessGroup element containing the BG
 	// with the name businessGroupName.
 	// Fetch the id of that

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -625,7 +625,7 @@ func readProviderConfiguration(d *schema.ResourceData, vraClient *sdk.APIClient)
 	}
 
 	// if catalog item name is provided, fetch the catalog item id
-	if len(providerSchema.CatalogItemName) > 0 {
+	if len(providerSchema.CatalogItemID) == 0 && len(providerSchema.CatalogItemName) > 0 {
 		id, err := vraClient.ReadCatalogItemByName(providerSchema.CatalogItemName)
 		if err != nil {
 			return &providerSchema, err
@@ -634,7 +634,7 @@ func readProviderConfiguration(d *schema.ResourceData, vraClient *sdk.APIClient)
 	}
 
 	// get the business group id from name
-	if len(providerSchema.BusinessGroupName) > 0 {
+	if len(providerSchema.BusinessGroupID) == 0 && len(providerSchema.BusinessGroupName) > 0 {
 		id, err := vraClient.GetBusinessGroupID(providerSchema.BusinessGroupName, vraClient.Tenant)
 		if err != nil {
 			return &providerSchema, err


### PR DESCRIPTION
Fetch business group id from business group name only when the id is not provided
Call the API /identity/api/tenants/{tenant}/subtenants/membership to fetch businessgroups
if /identity/api/tenants/{tenant}/subtenants returns empty response

Signed-off-by: Prativa Bawri <bawrip@vmware.com>