### PR TITLE
Added rejected state to vra deployment status

### DIFF
--- a/sdk/vra7_sdk.go
+++ b/sdk/vra7_sdk.go
@@ -34,6 +34,7 @@ const (
 	InProgress             = "IN_PROGRESS"
 	Successful             = "SUCCESSFUL"
 	Failed                 = "FAILED"
+	Rejected               = "REJECTED"
 	Submitted              = "SUBMITTED"
 	InfrastructureVirtual  = "Infrastructure.Virtual"
 	DeploymentResourceType = "composition.resource.type.deployment"

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -662,17 +662,17 @@ func waitForRequestCompletion(d *schema.ResourceData, meta interface{}, requestI
 	for i := 0; i < waitTimeout/sleepFor; i++ {
 		log.Info("Waiting for %d seconds before checking request status.", sleepFor)
 		time.Sleep(time.Duration(sleepFor) * time.Second)
-		reqestStatusView, _ := vraClient.GetRequestStatus(requestID)
-		status = reqestStatusView.Phase
+		requestStatusView, _ := vraClient.GetRequestStatus(requestID)
+		status = requestStatusView.Phase
 		d.Set("request_status", status)
 		log.Info("Checking to see the status of the request. Status: %s.", status)
 		if status == sdk.Successful {
 			log.Info("Request is SUCCESSFUL.")
 			return sdk.Successful, nil
 		} else if status == sdk.Failed {
-			return sdk.Failed, fmt.Errorf("Request failed \n %v ", reqestStatusView.RequestCompletion.CompletionDetails)
+			return sdk.Failed, fmt.Errorf("Request failed \n %v ", requestStatusView.RequestCompletion.CompletionDetails)
 		} else if status == sdk.Rejected {
-			return sdk.Rejected, fmt.Errorf("Request rejected \n %v ", reqestStatusView.RequestCompletion.CompletionDetails)
+			return sdk.Rejected, fmt.Errorf("Request rejected \n %v ", requestStatusView.RequestCompletion.CompletionDetails)
 		} else if status == sdk.InProgress {
 			log.Info("The request is still IN PROGRESS.")
 		} else {

--- a/vra7/resource_vra7_deployment.go
+++ b/vra7/resource_vra7_deployment.go
@@ -671,6 +671,8 @@ func waitForRequestCompletion(d *schema.ResourceData, meta interface{}, requestI
 			return sdk.Successful, nil
 		} else if status == sdk.Failed {
 			return sdk.Failed, fmt.Errorf("Request failed \n %v ", reqestStatusView.RequestCompletion.CompletionDetails)
+		} else if status == sdk.Rejected {
+			return sdk.Rejected, fmt.Errorf("Request rejected \n %v ", reqestStatusView.RequestCompletion.CompletionDetails)
 		} else if status == sdk.InProgress {
 			log.Info("The request is still IN PROGRESS.")
 		} else {


### PR DESCRIPTION
This change adds the "REJECTED" state to vRA deployment status. Without this state, terraform will loop forever if the deployment failed due to being rejected during pre-approval checks.

Signed-off-by: acidpizza <2451313+acidpizza@users.noreply.github.com>