### PR TITLE
fix "reason" to "reasons" in example/simple

### DIFF
--- a/example/simple/main.tf
+++ b/example/simple/main.tf
@@ -9,7 +9,7 @@ resource "vra7_deployment" "this" {
   count             = 1
   catalog_item_name = "CentOS 7.0 x64"
   description = "this description"
-  reason = "this reason"
+  reasons = "this reason"
   lease_days = 10
 
   deployment_configuration = {


### PR DESCRIPTION
Small fix in example/simple.
`  reason = "this reason"`
was wrong and returned an error
> An argument named "reason" is not expected here. Did you mean "reasons"?

Signed-off-by: ytpom <yttpom@gmail.com>
