### PR TITLE
Fix remote-exec example

### DIFF
--- a/example/remote-execute/main.tf
+++ b/example/remote-execute/main.tf
@@ -33,7 +33,7 @@ resource "vra7_deployment" "this" {
     host     = self.resource_configuration[*].ip_address
     user     = var.ssh_user
     password = var.ssh_password
-    type     = ssh
+    type     = "ssh"
   }
 
   // Extend volume to second disk


### PR DESCRIPTION
when used as it is it causes exception in validation 
Error: Invalid reference
│   on main.tf line 33, in resource "vra7_deployment" "this":
│   33:     type     = ssh
│ A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
Signed-off-by: Reddysekhar Gaduputi <gsekhar73@gmail.com>